### PR TITLE
Fix for function keys

### DIFF
--- a/client/gui/templates/default.lua
+++ b/client/gui/templates/default.lua
@@ -1048,7 +1048,7 @@ template.viewcontents = {
                 runfunction = function ( this )
                     for i=1,#validKeys do
                         guiComboBoxAddItem ( this, validKeys[i] )
-                        guicache.optionmenu_item[ validKeys[i] ] = i-1
+                        guicache.optionmenu_item[ string.lower( validKeys[i] ) ] = i-1
                     end
                     guiSetSize ( this, 100, ( 20 * #validKeys ) + 25, false )
                 end

--- a/server/utils.lua
+++ b/server/utils.lua
@@ -65,7 +65,7 @@ function handlingMod ( arg )
     }
 
     executeEvent[eventName]()
-    triggerClientEvent ( client, "showMenu", client, "previous" )
+    triggerClientEvent ( client, "showView", client, "previous" )
 
     return true
 end

--- a/server/utils.lua
+++ b/server/utils.lua
@@ -65,7 +65,7 @@ function handlingMod ( arg )
     }
 
     executeEvent[eventName]()
-    triggerClientEvent ( client, "showView", client, "previous" )
+    triggerClientEvent ( client, "showMenu", client, "previous" )
 
     return true
 end


### PR DESCRIPTION
When binding to function keys, usedKey will be capitalised (e.g. 'F5'). This is a fix for this case.